### PR TITLE
- Added `CreateAction` parameter `constructorView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.0.2] - 2021-05-20
+### Added
+- Added `CreateAction` parameter `constructorView`
+
 ## [3.0.0] - 2019-12-01
 ### Changed
 - Query builder separated in its own library

--- a/src/actions/conditions/CreateAction.php
+++ b/src/actions/conditions/CreateAction.php
@@ -2,12 +2,12 @@
 
 namespace micetm\conditions\actions\conditions;
 
-use micetm\conditionsBase\services\ConstructorService;
 use micetm\conditionsBase\models\AttributeInterface;
 use micetm\conditionsBase\models\ConditionInterface;
 use micetm\conditionsBase\models\constructor\conditions\Condition;
-use yii\base\Action;
+use micetm\conditionsBase\services\ConstructorService;
 use Yii;
+use yii\base\Action;
 
 class CreateAction extends Action
 {
@@ -20,46 +20,51 @@ class CreateAction extends Action
     public $defaultComparison = AttributeInterface::EQUAL_TO_COMPARISON;
     public $comparisonUrl;
     public $valueUrl;
+    public $constructorView = '@micetm/conditions/views/condition/ajax/_condition';
 
+    /**
+     * CreateAction constructor.
+     * @param $id
+     * @param $module
+     * @param array $config
+     */
     public function __construct(
-        $id,
-        $module,
-        array $config = []
+      $id,
+      $module,
+      array $config = []
     ) {
         parent::__construct($id, $module, $config);
     }
 
-    public function init()
-    {
-        parent::init();
-
-        if (!Yii::getAlias('@constructor-views', false)) {
-            Yii::setAlias('@constructor-views', __DIR__ . '/../../views');
-        }
-    }
-
+    /**
+     * @return string
+     */
     public function run()
     {
         $availableAttributes = $this->constructor->getAvailableAttributes();
-
         $request = Yii::$app->getRequest();
         $level = $request->getBodyParam('level', null);
         $position = $request->getBodyParam('position', 0);
         $path = $request->getBodyParam('path', '');
 
-        return $this->controller->renderAjax('@constructor-views/condition/ajax/_condition', [
-            'model' => new Condition([
+        return $this->controller->renderAjax(
+          $this->constructorView,
+          [
+            'model' => new Condition(
+              [
                 'operator' => ConditionInterface::OPERATOR_STATEMENT,
                 'attribute' => $this->defaultAttribute,
                 'comparison' => $this->defaultComparison,
                 "value" => $this->defaultValue,
-            ]),
+              ]
+            ),
             'availableAttributes' => $availableAttributes,
             'path' => $path,
-            'level' => is_null($level) ? 0 : $level+1,
+            'level' => is_null($level) ? 0 : $level + 1,
             'position' => $position,
             'comparisonUrl' => $this->comparisonUrl,
             'valueUrl' => $this->valueUrl
-        ]);
+          ]
+        );
     }
 }


### PR DESCRIPTION
example use 
```
/**
 * @return array
 */
public function actions(): array
{
    return ArrayHelper::merge(
      parent::actions(),
      [
        'condition-new' => [
          'class' => CreateAction::class,
          'constructor' => $this->constructor,
          'defaultAttribute' => 'propertyValues.features.id',
          'defaultComparison' => AttributeInterface::EQUAL_TO_COMPARISON,
          'comparisonUrl' => Url::to(['condition-comparison']),
          'valueUrl' => Url::to(['condition-value']),
          'constructorView' => '/service/condition/ajax/_condition',
        ],
      
      ]
    );
}
```